### PR TITLE
Remove some outdated code in the Emacs configuration

### DIFF
--- a/.emacs
+++ b/.emacs
@@ -94,11 +94,6 @@
             (setq-local comment-style 'indent)
             (setq-local tuareg-interactive-program
                         (concat tuareg-interactive-program " -nopromptcont"))
-            (let ((ext (file-name-extension buffer-file-name)))
-              (when (string-equal ext "eliom")
-                (setq-local ocamlformat-file-kind 'implementation))
-              (when (string-equal ext "eliomi")
-                (setq-local ocamlformat-file-kind 'interface)))
             (local-set-key (kbd "C-c C-a") 'ff-get-other-file)
             (add-hook 'before-save-hook 'ocamlformat-before-save t t)
             (merlin-mode)))


### PR DESCRIPTION
The removed piece of code was used to ensure that OCamlFormat deals
correctly with Eliom files.  This should not be needed anymore when
using a recent version of OCamlFormat, see:

https://github.com/ocaml-ppx/ocamlformat/blob/master/CHANGES.md#0150-2020-08-06
