### PR TITLE
Add a basic configuration for Visual Studio Code

### DIFF
--- a/.config/Code/User/settings.json
+++ b/.config/Code/User/settings.json
@@ -1,0 +1,10 @@
+{
+    "css.validate": false,
+    "editor.formatOnSave": true,
+    "files.insertFinalNewline": true,
+    "files.simpleDialog.enable": true,
+    "files.trimFinalNewlines": true,
+    "files.trimTrailingWhitespace": true,
+    "less.validate": false,
+    "scss.validate": false
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 !/Makefile
 !/README.md
 !/.besport_bashrc.bash
+!/.config/
+!/.config/Code
+!/.config/Code/User/
+!/.config/Code/User/settings.json
 !/.dockerignore
 !/.emacs.d/init.el
 !/.emacs.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ RUN opam update --yes && opam install --yes caml-mode ocaml-lsp-server \
     ocamlformat tuareg
 WORKDIR /home/besport
 COPY --chown=besport . .
-RUN make install
+RUN make install-bash-config install-emacs
 CMD ["bash"]

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ DOCKER_IMAGE_TAG = besport-dotfiles
 
 .SUFFIXES:
 .PHONY: all docker-build docker-debug-emacs-init install	\
-	install-bash-config install-emacs
+	install-bash-config install-emacs install-vscode
 
 all: docker-build
 
-install: install-bash-config install-emacs
+install: install-bash-config install-emacs install-vscode
 
 docker-build:
 	docker build --tag $(DOCKER_IMAGE_TAG) .
@@ -28,3 +28,8 @@ install-emacs:
 	  --eval "(progn					\
 		    (util-init-package-archives)		\
 		    (package-refresh-contents))"
+
+install-vscode:
+	code --install-extension esbenp.prettier-vscode
+	code --install-extension ocamllabs.ocaml-platform
+	code --install-extension stylelint.vscode-stylelint


### PR DESCRIPTION
The built-in linters for CSS/Less/SCSS files are disabled because
`stylelint` is used as linter instead (see
https://github.com/stylelint/vscode-stylelint#optional-but-recommended-setup).